### PR TITLE
Use config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOPATH := $(shell go env GOPATH)
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)
-ENPASS_VERSION := "0.4.10"
+ENPASS_VERSION := "0.5.0"
 
 GOOS ?= $(shell uname | tr '[:upper:]' '[:lower:]')
 GOARCH ?=$(shell arch)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ I wrote some Python scripts to manipulate my Enpass database, but I wanted to do
 * darwin or linux OS
 
 ## Installation
-Clone the repository and from within the repository directory, type `make build`. This will create a directory with the given value of `GOOS` and install the binary there. It will also create a tarball which will eventually be used for Homebrew formulae.
+* Clone the repository and from within the repository directory
+* Type `make build`. This will create a directory with the given value of `GOOS` and install the binary there. It will also create a tarball which will eventually be used for Homebrew formulae.
+* Copy <repo_root>/enpass.yml.SAMPLE to ~/.enpass.yml
 
 ## Features
 * List all entries from the database
@@ -22,7 +24,7 @@ Clone the repository and from within the repository directory, type `make build`
 * Filter by multiple logins (subtitles), titles, categories, or uuids using wildcards
 * Colorize output for JSON, YAML, list, and default views
 * Colors are defined centrally so all colorized outputs use the same color scheme
-* And more....
+* Basic options can be set in ~/.enpass.yml, please see enpass.yml.SAMPLE
 
 ## Usage
 ```

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -32,20 +32,7 @@ func copyPreRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func copyRunCmd(cmd *cobra.Command, args []string) {
-	if vaultPath == "" {
-		vaultPath, err = enpass.FindDefaultVaultPath()
-		if err != nil {
-			logger.Error(err)
-			logger.Exit(2)
-		}
-	}
-
-	err = enpass.ValidateVaultPath(vaultPath)
-	if err != nil {
-		logger.Error(err)
-		logger.Exit(2)
-	}
-
+	vaultPath := enpass.DetermineVaultPath(logger, vaultPathFlag)
 	vault, credentials, err = enpass.OpenVault(logger, pinEnable, nonInteractive, vaultPath, keyFilePath, logLevel, nocolorFlag)
 	if err != nil {
 		logger.Error(err)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -25,7 +25,7 @@ func getListShowFlags(cmd *cobra.Command) {
 }
 
 func GetPersistenFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVarP(&vaultPath, "vault", "v", "", "Path to your Enpass vault.")
+	cmd.PersistentFlags().StringVarP(&vaultPathFlag, "vault", "v", "", "Path to your Enpass vault.")
 	cmd.PersistentFlags().StringVar(&cardType, "type", "password", "The type of your card. (password, ...)")
 	cmd.PersistentFlags().StringArrayVarP(&recordTitle, "title", "t", []string{}, "Filter based on record title. Wildcards (%) are allowed. Can be used multiple times.")
 	cmd.PersistentFlags().StringArrayVarP(&recordCategory, "category", "c", []string{}, "Filter based on record category. Wildcards (%) are allowed. Can be used multiple times.")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -31,20 +31,7 @@ func listPreRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func listRunCmd(cmd *cobra.Command, args []string) {
-	if vaultPath == "" {
-		vaultPath, err = enpass.FindDefaultVaultPath()
-		if err != nil {
-			logger.Error(err)
-			logger.Exit(2)
-		}
-	}
-
-	err = enpass.ValidateVaultPath(vaultPath)
-	if err != nil {
-		logger.Error(err)
-		logger.Exit(2)
-	}
-
+	vaultPath := enpass.DetermineVaultPath(logger, vaultPathFlag)
 	vault, credentials, err = enpass.OpenVault(logger, pinEnable, nonInteractive, vaultPath, keyFilePath, logLevel, nocolorFlag)
 	if err != nil {
 		logger.Error(err)

--- a/cmd/pass.go
+++ b/cmd/pass.go
@@ -30,20 +30,7 @@ func passPreRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func passRunCmd(cmd *cobra.Command, args []string) {
-	if vaultPath == "" {
-		vaultPath, err = enpass.FindDefaultVaultPath()
-		if err != nil {
-			logger.Error(err)
-			logger.Exit(2)
-		}
-	}
-
-	err = enpass.ValidateVaultPath(vaultPath)
-	if err != nil {
-		logger.Error(err)
-		logger.Exit(2)
-	}
-
+	vaultPath := enpass.DetermineVaultPath(logger, vaultPathFlag)
 	vault, credentials, err = enpass.OpenVault(logger, pinEnable, nonInteractive, vaultPath, keyFilePath, logLevel, nocolorFlag)
 	if err != nil {
 		logger.Error(err)

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -29,20 +29,7 @@ func showPreRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func showRunCmd(cmd *cobra.Command, args []string) {
-	if vaultPath == "" {
-		vaultPath, err = enpass.FindDefaultVaultPath()
-		if err != nil {
-			logger.Error(err)
-			logger.Exit(2)
-		}
-	}
-
-	err = enpass.ValidateVaultPath(vaultPath)
-	if err != nil {
-		logger.Error(err)
-		logger.Exit(2)
-	}
-
+	vaultPath := enpass.DetermineVaultPath(logger, vaultPathFlag)
 	vault, credentials, err = enpass.OpenVault(logger, pinEnable, nonInteractive, vaultPath, keyFilePath, logLevel, nocolorFlag)
 	if err != nil {
 		logger.Error(err)

--- a/enpass.yml.SAMPLE
+++ b/enpass.yml.SAMPLE
@@ -1,0 +1,27 @@
+---
+# Valid colors
+# black-bold
+# black
+# blue-bold
+# blue
+# cyan-bold
+# cyan
+# green-bold
+# green
+# magenta-bold
+# magenta
+# red-bold
+# red
+# white-bold
+# white
+# yellow-bold
+# yellow
+colors:
+  alias_color: yellow-bold
+  anchor_color: yellow-bold
+  bool_color: yellow-bold
+  key_color: cyan-bold
+  null_color: black-bold
+  number_color: magenta-bold
+  string_color: green-bold
+vault_path: ~/Documents/Enpass/Vaults/primary

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -1,27 +1,73 @@
 package globals
 
 import (
+	"fmt"
+	"os/user"
 	"sync"
-
-	"github.com/fatih/color"
 )
+
+type Colors struct {
+	AliasColor  string `yaml:"alias_color"`
+	AnchorColor string `yaml:"anchor_color"`
+	BoolColor   string `yaml:"bool_color"`
+	KeyColor    string `yaml:"key_color"`
+	NullColor   string `yaml:"null_color"`
+	NumberColor string `yaml:"number_color"`
+	StringColor string `yaml:"string_color"`
+}
+
+type EnpassConfig struct {
+	VaultPath     string `yaml:"vault_path"`
+	VaultPassword string `yaml:"vault_password"`
+	Colors        Colors `yaml:"colors"`
+}
 
 var (
-	colorMap = map[string]color.Attribute{
-		"AliasColor":  color.FgHiYellow,
-		"AnchorColor": color.FgHiYellow,
-		"BoolColor":   color.FgHiYellow,
-		"KeyColor":    color.FgHiCyan,
-		"NullColor":   color.FgHiBlack,
-		"NumberColor": color.FgHiMagenta,
-		"StringColor": color.FgHiGreen,
+	enpassConfig = EnpassConfig{
+		VaultPath: "~/Documents/Enpass/Vaults/primary",
+		Colors: Colors{
+			AliasColor:  "yellow-bold",
+			AnchorColor: "yellow-bold",
+			BoolColor:   "yellow-bold",
+			KeyColor:    "cyan-bold",
+			NullColor:   "black-bold",
+			NumberColor: "magenta-bold",
+			StringColor: "green-bold",
+		},
 	}
-	mu sync.RWMutex
+	homeDir string
+	mu      sync.RWMutex
 )
 
-func GetColorMap() (x map[string]color.Attribute) {
+// Set and get pairs
+func SetConfig(x EnpassConfig) {
 	mu.Lock()
-	x = colorMap
+	enpassConfig = x
+	mu.Unlock()
+}
+
+func GetConfig() (x EnpassConfig) {
+	mu.Lock()
+	x = enpassConfig
+	mu.Unlock()
+	return x
+}
+
+func SetHomeDirectory() (err error) {
+	mu.Lock()
+	userObj, err := user.Current()
+	if err != nil {
+		mu.Unlock()
+		return fmt.Errorf("failed to determine the path of your home directory: %s", err)
+	}
+	homeDir = userObj.HomeDir
+	mu.Unlock()
+	return nil
+}
+
+func GetHomeDirectory() (x string) {
+	mu.Lock()
+	x = homeDir
 	mu.Unlock()
 	return x
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/thoas/go-funk v0.9.3
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	golang.org/x/crypto v0.26.0
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.25.11
 )
 

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,7 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/pkg/enpass/version.go
+++ b/pkg/enpass/version.go
@@ -7,8 +7,8 @@ import (
 
 var (
 	Major  = "0"
-	Minor  = "4"
-	Patch  = "10"
+	Minor  = "5"
+	Patch  = "0"
 	Suffix = "dev"
 )
 

--- a/pkg/output/json-output.go
+++ b/pkg/output/json-output.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
+	"github.com/gdanko/enpass/globals"
 	"github.com/gdanko/enpass/pkg/enpass"
 	"github.com/hokaccha/go-prettyjson"
 	"github.com/sirupsen/logrus"
 )
 
 func doJsonOutput(logger *logrus.Logger, cards []enpass.Card, nocolorFlag bool) {
-	colorMap := colorMap
 	disabledColor := false
 	if nocolorFlag {
 		disabledColor = true
@@ -18,11 +18,11 @@ func doJsonOutput(logger *logrus.Logger, cards []enpass.Card, nocolorFlag bool) 
 	formatter := prettyjson.NewFormatter()
 	formatter.DisabledColor = disabledColor
 	formatter.Indent = 4
-	formatter.BoolColor = color.New(colorMap["BoolColor"])
-	formatter.KeyColor = color.New(colorMap["KeyColor"])
-	formatter.NullColor = color.New(colorMap["NullColor"])
-	formatter.NumberColor = color.New(colorMap["NumberColor"])
-	formatter.StringColor = color.New(colorMap["StringColor"])
+	formatter.BoolColor = color.New(colorMap[globals.GetConfig().Colors.BoolColor])
+	formatter.KeyColor = color.New(colorMap[globals.GetConfig().Colors.KeyColor])
+	formatter.NullColor = color.New(colorMap[globals.GetConfig().Colors.NullColor])
+	formatter.NumberColor = color.New(colorMap[globals.GetConfig().Colors.NumberColor])
+	formatter.StringColor = color.New(colorMap[globals.GetConfig().Colors.StringColor])
 
 	jsonBytes, err := formatter.Marshal(cards)
 	if err != nil {

--- a/pkg/output/list-output.go
+++ b/pkg/output/list-output.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/gdanko/enpass/globals"
 	"github.com/gdanko/enpass/pkg/enpass"
 )
 
@@ -29,10 +30,10 @@ func doListOutput(cards []enpass.Card, cmdType string, nocolorFlag bool) {
 			}
 		} else {
 			var (
-				boolColor   = color.New(colorMap["BoolColor"]).SprintFunc()
-				keyColor    = color.New(colorMap["KeyColor"]).SprintFunc()
-				numberColor = color.New(colorMap["NumberColor"]).SprintFunc()
-				stringColor = color.New(colorMap["StringColor"]).SprintFunc()
+				boolColor   = color.New(colorMap[globals.GetConfig().Colors.BoolColor]).SprintFunc()
+				keyColor    = color.New(colorMap[globals.GetConfig().Colors.KeyColor]).SprintFunc()
+				numberColor = color.New(colorMap[globals.GetConfig().Colors.NumberColor]).SprintFunc()
+				stringColor = color.New(colorMap[globals.GetConfig().Colors.StringColor]).SprintFunc()
 			)
 			fmt.Printf("%s = %s\n", keyColor("      uuid"), stringColor(cardItem.UUID))
 			fmt.Printf("%s = %s\n", keyColor("   created"), numberColor(cardItem.CreatedAt))

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -10,14 +10,32 @@ import (
 )
 
 var (
+	// colorMap = map[string]color.Attribute{
+	// 	"AliasColor":  color.FgHiYellow,
+	// 	"AnchorColor": color.FgHiYellow,
+	// 	"BoolColor":   color.FgHiYellow,
+	// 	"KeyColor":    color.FgHiCyan,
+	// 	"NullColor":   color.FgHiBlack,
+	// 	"NumberColor": color.FgHiMagenta,
+	// 	"StringColor": color.FgHiGreen,
+	// }
 	colorMap = map[string]color.Attribute{
-		"AliasColor":  color.FgHiYellow,
-		"AnchorColor": color.FgHiYellow,
-		"BoolColor":   color.FgHiYellow,
-		"KeyColor":    color.FgHiCyan,
-		"NullColor":   color.FgHiBlack,
-		"NumberColor": color.FgHiMagenta,
-		"StringColor": color.FgHiGreen,
+		"black-bold":   color.FgHiBlack,
+		"black":        color.FgBlack,
+		"blue-bold":    color.FgHiBlue,
+		"blue":         color.FgBlue,
+		"cyan-bold":    color.FgHiCyan,
+		"cyan":         color.FgCyan,
+		"green-bold":   color.FgHiGreen,
+		"green":        color.FgGreen,
+		"magenta-bold": color.FgHiMagenta,
+		"magenta":      color.FgMagenta,
+		"red-bold":     color.FgHiRed,
+		"red":          color.FgRed,
+		"white-bold":   color.FgHiWhite,
+		"white":        color.FgWhite,
+		"yellow-bold":  color.FgHiYellow,
+		"yellow":       color.FgYellow,
 	}
 )
 

--- a/pkg/output/yaml-output.go
+++ b/pkg/output/yaml-output.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/gdanko/enpass/globals"
 	"github.com/gdanko/enpass/pkg/enpass"
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/lexer"
@@ -46,37 +47,37 @@ func doYamlOutput(logger *logrus.Logger, cards []enpass.Card, nocolorFlag bool) 
 		}
 		p.Alias = func() *printer.Property {
 			return &printer.Property{
-				Prefix: format(colorMap["AliasColor"]),
+				Prefix: format(colorMap[globals.GetConfig().Colors.AliasColor]),
 				Suffix: format(color.Reset),
 			}
 		}
 		p.Anchor = func() *printer.Property {
 			return &printer.Property{
-				Prefix: format(colorMap["AnchorColor"]),
+				Prefix: format(colorMap[globals.GetConfig().Colors.AnchorColor]),
 				Suffix: format(color.Reset),
 			}
 		}
 		p.Bool = func() *printer.Property {
 			return &printer.Property{
-				Prefix: format(colorMap["BoolColor"]),
+				Prefix: format(colorMap[globals.GetConfig().Colors.BoolColor]),
 				Suffix: format(color.Reset),
 			}
 		}
 		p.MapKey = func() *printer.Property {
 			return &printer.Property{
-				Prefix: format(colorMap["KeyColor"]),
+				Prefix: format(colorMap[globals.GetConfig().Colors.KeyColor]),
 				Suffix: format(color.Reset),
 			}
 		}
 		p.Number = func() *printer.Property {
 			return &printer.Property{
-				Prefix: format(colorMap["NumberColor"]),
+				Prefix: format(colorMap[globals.GetConfig().Colors.NumberColor]),
 				Suffix: format(color.Reset),
 			}
 		}
 		p.String = func() *printer.Property {
 			return &printer.Property{
-				Prefix: format(colorMap["StringColor"]),
+				Prefix: format(colorMap[globals.GetConfig().Colors.StringColor]),
 				Suffix: format(color.Reset),
 			}
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -1,14 +1,45 @@
 package util
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/gdanko/enpass/globals"
 	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
+	"gopkg.in/yaml.v3"
 )
 
+// FileOrDirectoryExists : Determine if a file or directory exists
+func FileOrDirectoryExists(path string) (exists bool, err error) {
+	_, err = os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, err
+	}
+
+	return false, err
+}
+
+// ReturnLogLevels : Return a comma-delimited list of log levels
+func ReturnLogLevels(levelMap map[string]logrus.Level) string {
+	logLevels := make([]string, 0, len(levelMap))
+	for k := range levelMap {
+		logLevels = append(logLevels, k)
+	}
+	sort.Strings(logLevels)
+
+	return strings.Join(logLevels, ", ")
+}
+
+// ConfigureLogger : Configure the logger
 func ConfigureLogger(logLevel logrus.Level, nocolorFlag bool) (logger *logrus.Logger) {
 	disableColors := false
 	if nocolorFlag {
@@ -17,28 +48,49 @@ func ConfigureLogger(logLevel logrus.Level, nocolorFlag bool) (logger *logrus.Lo
 	logger = &logrus.Logger{
 		Out:   os.Stderr,
 		Level: logLevel,
-		// Formatter: &easy.Formatter{
-		// 	TimestampFormat: "2006-01-02 15:04:05",
-		// 	LogFormat:       "[%lvl%]: %time% - %msg%",
-		// },
 		Formatter: &prefixed.TextFormatter{
 			DisableColors:    disableColors,
 			DisableTimestamp: true,
 			TimestampFormat:  "2006-01-02 15:04:05",
 			FullTimestamp:    true,
-			ForceFormatting:  true,
+			ForceFormatting:  false,
 		},
 	}
-
 	logger.SetLevel(logLevel)
+
 	return logger
 }
 
-func ReturnLogLevels(levelMap map[string]logrus.Level) string {
-	logLevels := make([]string, 0, len(levelMap))
-	for k := range levelMap {
-		logLevels = append(logLevels, k)
+// ExpandPath : Expand paths starting with ~/
+func ExpandPath(path string) (expanded string) {
+	if path == "~" {
+		expanded = globals.GetHomeDirectory()
+	} else if strings.HasPrefix(path, "~/") {
+		expanded = filepath.Join(globals.GetHomeDirectory(), path[2:])
+	} else {
+		expanded = path
 	}
-	sort.Strings(logLevels)
-	return strings.Join(logLevels, ", ")
+
+	return expanded
+}
+
+// ParseConfig : Read the config file and return it as an EnpassConfig object
+func ParseConfig(path string) (enpassConfig globals.EnpassConfig, err error) {
+	expanded := ExpandPath(path)
+	exists, err := FileOrDirectoryExists(ExpandPath(expanded))
+	if !exists && err != nil {
+		return globals.EnpassConfig{}, fmt.Errorf("the config file %s does not exist", expanded)
+	}
+
+	data, err := ioutil.ReadFile(expanded)
+	if err != nil {
+		return globals.EnpassConfig{}, fmt.Errorf("failed to read the config file %s: %s", expanded, err)
+	}
+
+	err = yaml.Unmarshal(data, &enpassConfig)
+	if err != nil {
+		return globals.EnpassConfig{}, fmt.Errorf("failed to parse the config file %s: %s", expanded, err)
+	}
+
+	return enpassConfig, nil
 }


### PR DESCRIPTION
## Changes

- Basic logic to parse a configuration file at ~/.enpass.yml
- Remove redundant vault validation functionality
- Colors and vault path can be configured